### PR TITLE
Trigger workflow only on source file changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,26 @@ name: Tests
 on:
   pull_request:
     branches: [main, master]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'jest.config.js'
+      - 'eslint.config.js'
+      - '.github/workflows/test.yml'
   push:
     branches: [main, master]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'jest.config.js'
+      - 'eslint.config.js'
+      - '.github/workflows/test.yml'
   workflow_dispatch: # Allows manual trigger
 
 permissions:


### PR DESCRIPTION
Add path filters to test workflow to prevent unnecessary CI runs on documentation changes. Workflow now only triggers on:
- Source files (src/**)
- Test files (tests/**)
- Build configuration (package.json, tsconfig.json, etc.)
- Workflow file itself

This prevents the workflow from running when README or other docs are updated.